### PR TITLE
Update crowdin.yml

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,19 +1,19 @@
 "preserve_hierarchy": true
-# Next line disables export of the currently untranslated languages.
-"export_languages": {
-                      "de",
-                      "es-ES",
-                      "fr",
-                      "pt-PT"
-}
+"export_languages": [
+    "de",
+    "es-ES",
+    "fr",
+    "pt-PT"
+]
 
 "files": [
 {
   "source": "/src/main/resources/*.properties",
-  "translation": "/src/main/resources/crowdin/%file_name%_%two_letters_code%.%file_extension%",
+  "translation": "/src/main/resources/crowdin/%file_name%_%osx_locale%.%file_extension%",
   "ignore": [
     "*_??.properties",
-    "log4j.properties"
+    "log4j.properties",
+    "/src/main/resources/crowdin"
   ],
   "type": "properties",
   "escape_quotes": 0,


### PR DESCRIPTION
Some minor improvements to your configuration file, you cannot use `%two_letters_code%` if both Chinese languages exist in the project (they are written to the same `zh` file on export, Chinese Traditional will overwrite Chinese Simplified each time)